### PR TITLE
1581 qupath geojson fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-.DS_Store
+*~
+*.swp
+*.sw0
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
-# docker
-This repo has docker containerization for Components Off the Shelf (COTS) being used in MIND.
+docker
+======
+This repo contains Dockerfiles and other artifacts for building docker images
+for various third-party tools used in MIND.
 
-## Configuration
-Common configurations needed for proper integration to be stored in /conf
+Software
+--------
+#### QuPath
+[QuPath](https://github.com/qupath/qupath) is a package for working with
+WSI pathology data.  [Stardist](https://github.com/qupath/qupath-extension-stardist) is a
+cell-segmentation model.
+
+#### DSA
+The Digital Slide Archive [DSA](https://digitalslidearchive.github.io/digital_slide_archive/)
+is a platform for visualizing and annotating whole-slide pathology images.
+
+#### Hive
+Apache [Hive](https://github.com/apache/hive) is a distributed data warehouse system, built on
+top of Apache Hadoop.
+
+Configuration
+-------------
+Common configurations needed for proper integration to be stored in `/conf`

--- a/qupath_tensorflow/Makefile
+++ b/qupath_tensorflow/Makefile
@@ -1,0 +1,29 @@
+ORG=mskmind
+NAME=qupath-tensorflow
+QPVER=0.2.3
+IMAGE=${NAME}:${QPVER}
+
+.PHONY: help build build-intel build-apple upload deploy
+.DEFAULT_GOAL := help
+
+# See https://dwmkerr.com/makefile-help-command/
+help: # Show help for each of the Makefile targets
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+
+build: build-intel # Build the docker image for intel
+
+build-apple: # Build the docker image for linux/arm64
+	docker buildx build --platform linux/arm64 -t $(IMAGE) .
+
+build-intel: # Build the docker image for linux/amd64
+	docker buildx build --platform linux/amd64 -t $(IMAGE) .
+
+upload: # Upload image to DockerHub
+	docker tag $(IMAGE) $(ORG)/$(IMAGE)
+	docker push $(ORG)/$(IMAGE)
+
+deploy: # Upload image to DockerHub
+	docker tag $(IMAGE) $(ORG)/$(NAME):current
+	docker push $(ORG)/$(NAME):current
+

--- a/qupath_tensorflow/README.md
+++ b/qupath_tensorflow/README.md
@@ -1,0 +1,33 @@
+qupath_tensorflow
+=================
+
+This folder is used to build an image for running QuPath with Tensorflow models.
+We currently use this image in `luna` for `stardist_lymphocyte` jobs.
+
+Name and Version
+----------------
+The version number should be the QuPath version number, plus a sequence
+number or some other label to distinguish different versions of our code
+(the groovy scripts, etc.)  The version that will be used in luna should
+*additionally* be tagged `current`.
+
+Build
+-----
+    NAME="qupath-tensorflow"
+    VERSION=0.2.3
+
+    docker build -t ${NAME}:${VERSION} .
+
+Installation
+------------
+Add the newly built image to DockerHub with the command
+
+    docker push mskmind/${NAME}:${VERSION}
+
+When you're ready to make this the version that's used by luna, apply
+the `current` tag to this image with
+
+    docker tag ${NAME}:${VERSION} ${NAME}:current
+    docker push mskmind/${NAME}:current
+
+

--- a/qupath_tensorflow/scripts/stardist_nuclei_and_lymphocytes.groovy
+++ b/qupath_tensorflow/scripts/stardist_nuclei_and_lymphocytes.groovy
@@ -54,7 +54,8 @@ selectDetections();
 runObjectClassifier("/classifier-models/ANN_StardistSeg3.0CellExp1.0CellConstraint_AllFeatures_LymphClassifier.json")
 saveDetectionMeasurements('/output_dir/cell_detections.tsv')
 
+def detection_objects = ['type': 'FeatureCollection', 'features': celldetections]
 def detection_geojson = GsonTools.getInstance(true)
 new File('/output_dir/cell_detections.geojson').withWriter('UTF-8') {
-    detection_geojson.toJson(celldetections, it)
+    detection_geojson.toJson(detection_objects, it)
 }

--- a/stardist_cuda/Makefile
+++ b/stardist_cuda/Makefile
@@ -1,0 +1,29 @@
+ORG=mskmind
+NAME=qupath-stardist
+QPVER=0.4.3
+IMAGE=${NAME}:${QPVER}-1
+
+.PHONY: help build build-intel build-apple upload deploy
+.DEFAULT_GOAL := help
+
+# See https://dwmkerr.com/makefile-help-command/
+help: # Show help for each of the Makefile targets
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+
+build: build-intel # Build the docker image for intel
+
+build-apple: # Build the docker image for linux/arm64
+	docker buildx build --platform linux/arm64 -t $(IMAGE) .
+
+build-intel: # Build the docker image for linux/amd64
+	docker buildx build --platform linux/amd64 -t $(IMAGE) .
+
+upload: # Upload image to DockerHub
+	docker tag $(IMAGE) $(ORG)/$(IMAGE)
+	docker push $(ORG)/$(IMAGE)
+
+deploy: # Upload image to DockerHub
+	docker tag $(IMAGE) $(ORG)/$(NAME):current
+	docker push $(ORG)/$(NAME):current
+

--- a/stardist_cuda/README.md
+++ b/stardist_cuda/README.md
@@ -1,0 +1,31 @@
+stardist_cuda
+=============
+
+This folder is used to build an image for running QuPath with CUDA support.
+We currently use this image in `luna` for `stardist_simple` jobs.
+
+The version number should be the QuPath version number, plus a sequence
+number or some other label to distinguish different versions of our code
+(the groovy scripts, etc.)  The version that will be used in luna should
+*additionally* be tagged `current`.
+
+Build
+-----
+    NAME="qupath_stardist"
+    VERSION=0.4.3-1
+
+    docker build -t ${NAME}:${VERSION} .
+
+Installation
+------------
+Add the newly built image to DockerHub with the command
+
+    docker push mskmind/${NAME}:${VERSION}
+
+When you're ready to make this the version that's used by luna, apply
+the `current` tag to this image with
+
+    docker tag ${NAME}:${VERSION} ${NAME}:current
+    docker push mskmind/${NAME}:current
+
+

--- a/stardist_cuda/scripts/stardist_nuclei_and_lymphocytes.groovy
+++ b/stardist_cuda/scripts/stardist_nuclei_and_lymphocytes.groovy
@@ -54,7 +54,8 @@ selectDetections();
 runObjectClassifier("/classifier-models/ANN_StardistSeg3.0CellExp1.0CellConstraint_AllFeatures_LymphClassifier.json")
 saveDetectionMeasurements('/output_dir/cell_detections.tsv')
 
+def detection_objects = ['type': 'FeatureCollection', 'features': celldetections]
 def detection_geojson = GsonTools.getInstance(true)
 new File('/output_dir/cell_detections.geojson').withWriter('UTF-8') {
-    detection_geojson.toJson(celldetections, it)
+    detection_geojson.toJson(detection_objects, it)
 }

--- a/stardist_cuda/scripts/stardist_simple.groovy
+++ b/stardist_cuda/scripts/stardist_simple.groovy
@@ -73,7 +73,7 @@ logger.info("Started writing cell object data...")
 saveDetectionMeasurements('/output_dir/cell_detections.tsv')
 
 logger.info("Started writing cell object geojson...")
-def detection_objects = getDetectionObjects()
+def detection_objects = ['type': 'FeatureCollection', 'features': getDetectionObjects()]
 def detection_geojson = GsonTools.getInstance(true)
 new File('/output_dir/cell_detections.geojson').withWriter('UTF-8') {
     detection_geojson.toJson(detection_objects, it)


### PR DESCRIPTION
The main changes here are to the groovy scripts used in the QuPath images.  They should produce valid GeoJSON files now.
README's and Makefiles were added to the two folders, `qupath_tensorflow` and `stardist_cuda`.

This PR also introduces the convention to use the tag `current` on the images that luna will use. 